### PR TITLE
Fix lualine filetype

### DIFF
--- a/nvim/.config/nvim/lua/init/plugins/lualine.lua
+++ b/nvim/.config/nvim/lua/init/plugins/lualine.lua
@@ -18,7 +18,7 @@ return {
           },
           { "encoding" },
           { "fileformat" },
-          { "filetipe" },
+          { "filetype" },
         },
       },
     })


### PR DESCRIPTION
## Summary
- fix lualine filetype display

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684473a25478832f8dfe5db1822acfec