### PR TITLE
Remove stray print from lspconfig

### DIFF
--- a/nvim/.config/nvim/lua/init/plugins/lsp/lspconfig.lua
+++ b/nvim/.config/nvim/lua/init/plugins/lsp/lspconfig.lua
@@ -70,7 +70,6 @@ return {
     local capabilities = cmp_nvim_lsp.default_capabilities()
 
     for _, server in ipairs(mason_lspconfig.get_installed_servers()) do
-      print("Setting up " .. server)
       local opts = { capabilities = capabilities }
 
       if server == "lua_ls" then


### PR DESCRIPTION
## Summary
- removed the debug `print` when configuring LSP servers

## Testing
- `grep -R "print(" -n`

------
https://chatgpt.com/codex/tasks/task_e_68440a6383fc832fa498d75e87708155