### PR TITLE
Update jdtls workspace path

### DIFF
--- a/nvim/.config/nvim/lua/init/plugins/lsp/java.lua
+++ b/nvim/.config/nvim/lua/init/plugins/lsp/java.lua
@@ -10,7 +10,7 @@ return {
     local config_os = vim.fn.has("mac") == 1 and "mac" or (vim.fn.has("win32") == 1 and "win" or "linux")
 
     local project_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":p:h:t")
-    local workspace_dir = nvim_data_path .. "/jdtals-workspace/" .. project_name
+    local workspace_dir = nvim_data_path .. "/jdtls-workspace/" .. project_name
     vim.fn.mkdir(workspace_dir, "p")
 
     local java_debug_path = nvim_data_path .. "/mason/packages/java-debug-adapter"


### PR DESCRIPTION
## Summary
- adjust the default workspace directory name for the jdtls plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684479ddaa48832fb9ba7472bb599fc0