### PR TITLE
Fix nvim-treesitter option

### DIFF
--- a/nvim/.config/nvim/lua/init/plugins/nvim-treesitter.lua
+++ b/nvim/.config/nvim/lua/init/plugins/nvim-treesitter.lua
@@ -8,7 +8,7 @@ return {
   config = function()
     local treesitter = require("nvim-treesitter.configs")
     treesitter.setup({
-      ensurere_installed = {
+      ensure_installed = {
         "rust",
         "toml",
         "java",


### PR DESCRIPTION
## Summary
- fix a typo in the Treesitter configuration so plugins install correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684479da4a44832faaf7a64ce8d0b9ce